### PR TITLE
fix(readme): correct heading format and fix indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,40 +20,43 @@ These instructions will help you set up and run the Pixelize CC Discord bot on y
 
 ### Installation
 
-1. Clone this repository to your local machine:
+1\. **Fork this repository and make a clone in your local machine:**
 
    ```sh
    git clone https://github.com/yourusername/pixelize-cc.git
    cd pixelize-cc
    npm install
    ```
-2. Set up your configuration:
 
-  Go to config.json file in the root directory.
+2\. **Set up your configuration:**<br>
+&nbsp;&nbsp;&nbsp;&nbsp;Go to config.json file in the root directory.
   Add your Discord bot token to the config.json file:
   ```
   {
     "token": "your token here"
   }
   ```
-3. Start the bot:
-   Run in your terminal
+
+3\. **Start the bot:**<br>
+   &nbsp;&nbsp;&nbsp;&nbsp;Run in your terminal
+
     ```
     node .
     ```
+
 The bot should now be running on your server.
 
-##Usage
+## Usage
 Invite the bot to your Discord server using the invite link provided in the Discord Developer Portal.
 Configure and customize the bot's functionality to suit your server's needs.
 Use the command prefix to interact with the bot and enjoy its features.
 
-###Contributing
+### Contributing
 Contributions are welcome! If you'd like to contribute to Pixelize CC, please follow the Contributing Guidelines.
 
-##License
+## License
 This project is licensed under the MIT License - see the LICENSE file for details.
 
-##Acknowledgments
+## Acknowledgments
 The Discord.js library for enabling bot development.
 Our amazing community of users for their support and feedback.


### PR DESCRIPTION
The headings for Usage, License, etc. were incorrectly formatted, missing a space. In addition, this commit also fixes the indentation issues with the "Installation" section.

Old "Installation" section:
![2023-10-24_15-51](https://github.com/pixelizecc/discord-bot-v1/assets/93624576/cd1890a8-2d47-4730-8497-7e1b1697ab9a)

New "Installation" section:
![image](https://github.com/pixelizecc/discord-bot-v1/assets/93624576/f7ce0b01-d0be-4474-9fbe-a4597b04b663)
